### PR TITLE
fixed app crashing when port input is empty

### DIFF
--- a/app/src/main/java/com/android/dippid/DebugFragment.kt
+++ b/app/src/main/java/com/android/dippid/DebugFragment.kt
@@ -8,6 +8,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.Bundle
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.widget.Button
@@ -17,6 +18,7 @@ import android.widget.Toast
 import androidx.appcompat.widget.SwitchCompat
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
+import java.lang.NumberFormatException
 import java.net.InetAddress
 import java.util.*
 
@@ -111,7 +113,13 @@ class DebugFragment : Fragment(R.layout.fragment_debug), SensorEventListener {
         }
         portInput.doOnTextChanged { text, _, _, _ ->
             if (text != null) {
-                port = Integer.parseInt(text.toString())
+                try {
+                    port = Integer.parseInt(text.toString())
+                } catch (ex: NumberFormatException) {
+                    port = 5700
+                    Log.e("PORT", "Could not format Port input to Integer. Using default" +
+                            " port instead (5700)")
+                }
             }
 
             if (sharedPref != null) {


### PR DESCRIPTION
Fix for issue #1 

When the input is empty, the ``doOnTextChanged`` function gets passed "". The app then throws a NumberFormatException, since "" cannot be formatted to an integer.

Can be fixed in different ways, I thought it would be neat to catch the exception and set the port to the default used in our course (5700) so the app continues to work.